### PR TITLE
chore(ci): update track branches in scan-images.yaml

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -12,7 +12,7 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-published-images-scan-and-report.yaml@main
     strategy:
       matrix:
-        branch: [main, track/1.0]
+        branch: [main]
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -12,7 +12,7 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-published-images-scan-and-report.yaml@main
     strategy:
       matrix:
-        branch: [track/1.0]
+        branch: [main, track/1.0]
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:


### PR DESCRIPTION
Update track branches to the current supported ones. Note that main corresponds to the latest CKF version (1.10).

Ref canonical/bundle-kubeflow#1212