### PR TITLE
feat: use chaci + v3 bump

### DIFF
--- a/.github/workflows/build_and_publish_rock.yaml
+++ b/.github/workflows/build_and_publish_rock.yaml
@@ -1,0 +1,39 @@
+# reusable workflow for publishing a rock
+name: Build and publish rock
+
+on:
+  workflow_call:
+    inputs:
+      rock-dir:
+        description: "Path to rock directory, i.e. directory containing rockcraft.yaml"
+        required: true
+        default: '.'
+        type: string
+      source-branch:
+        description: Github branch from this repo to publish.  If blank, will use the default branch
+        default: ''
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      rock-dir:
+        description: "Path to rock directory, i.e. directory containing rockcraft.yaml"
+        required: true
+        default: '.'
+        type: string
+      source-branch:
+        description: Github branch from this repo to publish.  If blank, will use the default branch
+        default: ''
+        required: false
+        type: string
+
+jobs:
+  build-publish-rock:
+    name: Build and publish rock
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/build_and_publish_rock.yaml@main
+    with:
+      rock-dir: ${{ inputs.rock-dir }}
+      source-branch: ${{ inputs.source-branch }}
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/resource-dispatcher/rock-ci-metadata.yaml
+++ b/resource-dispatcher/rock-ci-metadata.yaml
@@ -1,0 +1,5 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/resource-dispatcher.git
+    replace-image:
+      - file: metadata.yaml
+        path: resources.oci-image.upstream-source

--- a/resource-dispatcher/rockcraft.yaml
+++ b/resource-dispatcher/rockcraft.yaml
@@ -5,7 +5,7 @@ description: |
   For each GET request on the /sync path, the resource dispatcher will generate Kubernetes manifests 
   that need to be injected into the given Kubernetes namespace. Information about the Kubernetes 
   namespace should be included in the body of the request. 
-version: "2.0"
+version: "3.0"
 base: ubuntu@22.04
 license: Apache-2.0
 


### PR DESCRIPTION
Closes: https://github.com/canonical/resource-dispatcher-rock/issues/15

We are also bumping the version to v3 because the resource-dispatcher code in main was updated for new version here: https://github.com/canonical/resource-dispatcher-image/pull/43