### PR TITLE
feat: bump version to 3.3 to add ConfigMaps support

### DIFF
--- a/resource-dispatcher/rockcraft.yaml
+++ b/resource-dispatcher/rockcraft.yaml
@@ -5,7 +5,7 @@ description: |
   For each GET request on the /sync path, the resource dispatcher will generate Kubernetes manifests 
   that need to be injected into the given Kubernetes namespace. Information about the Kubernetes 
   namespace should be included in the body of the request. 
-version: "3.2"
+version: "3.3"
 base: ubuntu@22.04
 license: Apache-2.0
 


### PR DESCRIPTION
This PR bumps version to `3.3` to add `ConfigMaps` support.